### PR TITLE
Fix API callback not passing error correctly

### DIFF
--- a/paladins-api.js
+++ b/paladins-api.js
@@ -156,16 +156,18 @@ module.exports = class API {
 
   makeRequest(url, send) {
     request(url, function(err, res, body) {
-      if(!err) {
+      // The callback will be invoked with these variables, one should be filled one should be left null.
+      var localError = null, bodyParsed = null;
+      if(!err)
         try {
-          var bodyParsed = JSON.parse(body);
+          bodyParsed = JSON.parse(body);
         } catch(e) {
-          var bodyParsed = { error: 'Paladins API down.' };
+          localError = { error: 'Paladins API down.', exception: e };
         }
-        send(err, bodyParsed);
       } else {
-        console.log(err);
+        localError = { error: 'Paladins API down.', data: err };
       }
+      send(localError, bodyParsed);
     });
   }
 


### PR DESCRIPTION
The `err` object in the callback of `fetchUrl` is an object of some sort ([source](https://github.com/andris9/fetch/blob/c58142f56de8406a68b99e747391575e6bda949f/lib/fetch.js#L405))

I have formatted the error object passed to the callback as follows:

Key | type | meaning
--- | --- | ---
error | string | description of error
data | object | error object returned by `fetchUrl` (if error occurred there)
exception | object | exception object thrown by `JSON.parse` (if error occurred there)

Also according to this code if there is an HTTP error the callback never fires to the consumer of the library. This is no longer the case, the callback always fires with appropriate error and result arguments now.

#5 